### PR TITLE
feat: `testing.T` `#Cleanup()` support

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -17,3 +17,10 @@ Feature: hooks
     And expect scenario tag "@long"
     # And step level resources are cleaned up
     # And after all tests are done resources are closed
+
+  Scenario: testingT cleanup
+    When I open a resource with cleanup
+    Then it is open
+    And expect scenario name "testingT cleanup"
+    # And step level resources are cleaned up
+    # And after all tests are done resources are closed

--- a/run_scenario.go
+++ b/run_scenario.go
@@ -50,7 +50,8 @@ func (r *docRunner) runScenario(t *testing.T, pickle *messages.Pickle) {
 	}
 
 	if useRapid {
-		rapid.Check(t, func(t *rapid.T) {
+		rapid.Check(t, func(rt *rapid.T) {
+			t := &rapidT{rt}
 			(&scenarioRunner{
 				docRunner: r,
 				t:         t,
@@ -103,9 +104,12 @@ func (r *scenarioRunner) runTestCase() {
 	}
 
 	for _, hook := range r.afterHooks {
-		if t, ok := r.t.(interface{ Cleanup(func()) }); ok {
+		switch t := r.t.(type) {
+		case *rapidT:
+			defer r.runHook(hook)
+		case interface{ Cleanup(func()) }:
 			t.Cleanup(func() { r.runHook(hook) })
-		} else {
+		default:
 			defer r.runHook(hook)
 		}
 	}

--- a/runner.go
+++ b/runner.go
@@ -67,8 +67,8 @@ func NewRunner(t *testing.T, suiteType interface{}) *Runner {
 			},
 			// *rapid.T
 			reflect.TypeOf(&rapid.T{}): func(runner *scenarioRunner) interface{} {
-				if t, ok := runner.t.(*rapid.T); ok {
-					return t
+				if t, ok := runner.t.(*rapidT); ok {
+					return t.T
 				}
 				runner.t.Fatalf("expected %T, but got %T", &rapid.T{}, runner.t)
 				return nil

--- a/testingt.go
+++ b/testingt.go
@@ -1,5 +1,7 @@
 package gocuke
 
+import "pgregory.net/rapid"
+
 // TestingT is the common subset of testing methods exposed to test suite
 // instances and expected by common assertion and mocking libraries.
 type TestingT interface {
@@ -17,4 +19,14 @@ type TestingT interface {
 	SkipNow()
 	Skipf(format string, args ...interface{})
 	Helper()
+}
+
+// rapidT is a wrapper around `*rapid.T` that stubs missing `TestingT`
+// interface members (e.g. `Cleanup()`).
+type rapidT struct {
+	*rapid.T
+}
+
+func (rt *rapidT) Cleanup(fn func()) {
+	rt.Log("WARNING: cleanup called on `*rapid.T`")
 }

--- a/testingt.go
+++ b/testingt.go
@@ -3,6 +3,7 @@ package gocuke
 // TestingT is the common subset of testing methods exposed to test suite
 // instances and expected by common assertion and mocking libraries.
 type TestingT interface {
+	Cleanup(func())
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
 	Fail()


### PR DESCRIPTION
## Summary

This pull request introduces a wrapper for `*rapid.T` called `rapidT` to address compatibility issues with the `TestingT` interface. The changes include adding a `Cleanup()` method to the `TestingT` interface and implementing the `rapidT` wrapper with a stub for the `Cleanup()` method. The wrapper is used in `runScenario` function to maintain compatibility and provide better integration between rapid and testing packages.

## Use case

We have some non-trivial, common test helpers that occasionally reach for `t.Cleanup(...)`. I acknowledge that the `After` is intended for suite cleanup but I think this is an equally valid case.